### PR TITLE
fix: empty Hash being converted to Array

### DIFF
--- a/lib/grape_jsonapi/formatter.rb
+++ b/lib/grape_jsonapi/formatter.rb
@@ -25,10 +25,10 @@ module Grape
         def serialize(object, env)
           if object.respond_to?(:serializable_hash)
             serializable_object(object, jsonapi_options(env)).serializable_hash
-          elsif serializable_collection?(object)
-            serializable_collection(object, jsonapi_options(env))
           elsif object.is_a?(Hash)
             serialize_each_pair(object, env)
+          elsif serializable_collection?(object)
+            serializable_collection(object, jsonapi_options(env))
           else
             object
           end

--- a/lib/grape_jsonapi/formatter.rb
+++ b/lib/grape_jsonapi/formatter.rb
@@ -35,7 +35,7 @@ module Grape
         end
 
         def serializable_collection?(object)
-          object.respond_to?(:to_a) && object.all? do |o|
+          object && object.respond_to?(:to_a) && object.all? do |o|
             o.respond_to?(:serializable_hash)
           end
         end

--- a/lib/grape_jsonapi/parser.rb
+++ b/lib/grape_jsonapi/parser.rb
@@ -96,7 +96,7 @@ module GrapeSwagger
         activerecord_model.columns.each_with_object({}) do |column, attributes|
           next unless model.attributes_to_serialize.key?(column.name.to_sym)
           if model.respond_to?(:attribute_types) && model.attribute_types[attribute]
-            attributes[column.name] = model.attribute_types[attribute]
+            attributes[column.name] = model.attribute_types[column.name]
           else
             attributes[column.name] = column.type
           end

--- a/lib/grape_jsonapi/parser.rb
+++ b/lib/grape_jsonapi/parser.rb
@@ -95,8 +95,11 @@ module GrapeSwagger
 
         activerecord_model.columns.each_with_object({}) do |column, attributes|
           next unless model.attributes_to_serialize.key?(column.name.to_sym)
-
-          attributes[column.name] = column.type
+          if model.respond_to? :attribute_types && model.attribute_types[attribute]
+            attributes[column.name] = model.attribute_types[attribute]
+          else
+            attributes[column.name] = column.type
+          end
         end
       end
 

--- a/lib/grape_jsonapi/parser.rb
+++ b/lib/grape_jsonapi/parser.rb
@@ -94,9 +94,10 @@ module GrapeSwagger
         return map_model_attributes unless activerecord_model && activerecord_model < ActiveRecord::Base
 
         activerecord_model.columns.each_with_object({}) do |column, attributes|
-          next unless model.attributes_to_serialize.key?(column.name.to_sym)
-          if model.respond_to?(:attribute_types) && model.attribute_types[column.name]
-            attributes[column.name] = model.attribute_types[column.name]
+          attribute = column.name.to_sym
+          next unless model.attributes_to_serialize.key?(attribute)
+          if model.respond_to?(:attribute_types) && model.attribute_types[attribute]
+            attributes[column.name] = model.attribute_types[attribute]
           else
             attributes[column.name] = column.type
           end

--- a/lib/grape_jsonapi/parser.rb
+++ b/lib/grape_jsonapi/parser.rb
@@ -95,7 +95,7 @@ module GrapeSwagger
 
         activerecord_model.columns.each_with_object({}) do |column, attributes|
           next unless model.attributes_to_serialize.key?(column.name.to_sym)
-          if model.respond_to? :attribute_types && model.attribute_types[attribute]
+          if model.respond_to?(:attribute_types) && model.attribute_types[attribute]
             attributes[column.name] = model.attribute_types[attribute]
           else
             attributes[column.name] = column.type

--- a/lib/grape_jsonapi/parser.rb
+++ b/lib/grape_jsonapi/parser.rb
@@ -95,7 +95,7 @@ module GrapeSwagger
 
         activerecord_model.columns.each_with_object({}) do |column, attributes|
           next unless model.attributes_to_serialize.key?(column.name.to_sym)
-          if model.respond_to?(:attribute_types) && model.attribute_types[attribute]
+          if model.respond_to?(:attribute_types) && model.attribute_types[column.name]
             attributes[column.name] = model.attribute_types[column.name]
           else
             attributes[column.name] = column.type


### PR DESCRIPTION
Because an empty hash was passing the `serializable_collection?` check it was being converted to an empty array.