### PR TITLE
Add float example method

### DIFF
--- a/lib/grape_fast_jsonapi/parser.rb
+++ b/lib/grape_fast_jsonapi/parser.rb
@@ -188,6 +188,14 @@ module GrapeSwagger
       def uuid_example
         SecureRandom.uuid
       end
+
+      def float_example
+        if defined? Faker
+          Faker::Number.decimal
+        else
+          rand(1..9999) / 10.0
+        end
+      end
     end
   end
 end

--- a/lib/grape_fast_jsonapi/version.rb
+++ b/lib/grape_fast_jsonapi/version.rb
@@ -2,6 +2,6 @@
 
 module Grape
   module FastJsonapi
-    VERSION = '0.2.5'.freeze
+    VERSION = '0.2.6'.freeze
   end
 end


### PR DESCRIPTION
There was missing example for attributes with float type, which was raising `undefined method `float_example' ` error